### PR TITLE
feat(indexers): Add stress test to compare vector indexer

### DIFF
--- a/vector_index/.gitignore
+++ b/vector_index/.gitignore
@@ -1,0 +1,2 @@
+faiss_data/
+workspace/

--- a/vector_index/app.py
+++ b/vector_index/app.py
@@ -3,7 +3,8 @@ import os
 import numpy as np
 from jina.executors import BaseExecutor
 from jina.executors.indexers.vector.faiss import FaissIndexer
-from jina.executors.indexers.vector import BaseNumpyIndexer
+from jina.executors.indexers.vector.annoy import AnnoyIndexer
+from jina.executors.indexers.vector.numpy import NumpyIndexer
 from read_vectors_files import fvecs_read, ivecs_read
 from perf_timer import PerfTimer
 
@@ -13,7 +14,9 @@ FAISS_DATA_DIR = os.path.join(os.path.join(os.path.dirname(__file__), "faiss_dat
 INDEX_FEED_PATH = os.path.join(FAISS_DATA_DIR, "sift_base.fvecs")
 QUERY_FEED_PATH = os.path.join(FAISS_DATA_DIR, "sift_query.fvecs")
 GROUNDTRUTH_PATH = os.path.join(FAISS_DATA_DIR, 'sift_groundtruth.ivecs')
-INDEXER_BIN_SAVE_PATH = os.path.join(WORKSPACE_DIR, "indexer.bin")
+FAISS_INDEXER_BIN_SAVE_PATH = os.path.join(WORKSPACE_DIR, "faiss-indexer.bin")
+ANNOY_INDEXER_BIN_SAVE_PATH = os.path.join(WORKSPACE_DIR, "annoy-indexer.bin")
+NUMPY_INDEXER_BIN_SAVE_PATH = os.path.join(WORKSPACE_DIR, "numpy-indexer.bin")
 
 
 def read_data(db_file_path: str, batch_size: int, max_docs: int = None):
@@ -33,25 +36,25 @@ def read_data(db_file_path: str, batch_size: int, max_docs: int = None):
         yield keys, vectors[start_batch: end_batch]
 
 
-def index(indexer: 'BaseNumpyIndexer', batch_size: int):
+def do_index(indexer: 'BaseNumpyIndexer', batch_size: int):
     t = PerfTimer()
     with t:
         n = 0
         for keys, vecs in read_data(INDEX_FEED_PATH, batch_size):
             indexer.add(keys, vecs)
             n += batch_size
-    print(f'Took {t.interval} m to index {n} documents: {n/t.interval}doc/s')
+    print(f'Took {t.interval} seconds to index {n} documents: {n / t.interval} doc/s')
 
 
-def train(indexer: 'BaseNumpyIndexer'):
+def do_warmup(indexer: 'BaseNumpyIndexer'):
     t = PerfTimer()
     with t:
         for keys, vecs in read_data(QUERY_FEED_PATH, batch_size=1, max_docs=100):
             indexer.query(vecs, 1)
-    print(f'Took {t.interval} m to train and warmup the index')
+    print(f'Took {t.interval} seconds to train and warmup the index')
 
 
-def query(indexer: 'BaseNumpyIndexer', batch_size: int, top_k: int):
+def do_query(indexer: 'BaseNumpyIndexer', batch_size: int, top_k: int):
     results = np.empty((0, top_k), 'float32')
     t = PerfTimer()
     with t:
@@ -60,11 +63,11 @@ def query(indexer: 'BaseNumpyIndexer', batch_size: int, top_k: int):
             doc_ids, dists = indexer.query(vecs, top_k)
             results = np.vstack((results, doc_ids))
             n += batch_size
-    print(f'Took {t.interval} m to query {n} documents: {n/t.interval}doc/s')
+    print(f'Took {t.interval} seconds to query {n} documents: {n / t.interval} doc/s')
     return results
 
 
-def evaluate(results: np.array):
+def do_evaluate(results: np.array):
     groundtruth = ivecs_read(GROUNDTRUTH_PATH)
 
     def recall_at_k(k):
@@ -79,10 +82,25 @@ def evaluate(results: np.array):
         print(f'recall@{eval_point} = {recall_at_k(eval_point)}')
 
 
-def get_indexer(save_abspath: str = None):
-    if save_abspath is None:
-        return FaissIndexer(index_key='IVF10,PQ4', train_filepath=os.path.join(WORKSPACE_DIR, "train.tgz"),
-                            index_filename="index.tgz", compress_level=1,
+def get_faiss_indexer(save_abspath: str = None):
+    if save_abspath is None or os.path.exists(save_abspath) is False:
+        return FaissIndexer(index_key='IVF4096,PQ64', train_filepath=os.path.join(WORKSPACE_DIR, "train.tgz"),
+                            index_filename="faiss-index.tgz", compress_level=1,
+                            metas={'workspace': WORKSPACE_DIR,
+                                   'warn_unnamed': False,
+                                   'separated_workspace': False,
+                                   'is_trained': False,
+                                   'max_snapshot': 0,
+                                   'on_gpu': False
+                                   })
+    else:
+        return BaseExecutor.load(save_abspath)
+
+
+def get_annoy_indexer(save_abspath: str = None):
+    if save_abspath is None or os.path.exists(save_abspath) is False:
+        return AnnoyIndexer(metric='euclidean', ntrees=10,
+                            index_filename="annoy-index.tgz", compress_level=1,
                             metas={'workspace': WORKSPACE_DIR,
                                    'warn_unnamed': False,
                                    'separated_workspace': False,
@@ -93,26 +111,59 @@ def get_indexer(save_abspath: str = None):
         return BaseExecutor.load(save_abspath)
 
 
+def get_numpy_indexer(save_abspath: str = None):
+    if save_abspath is None or os.path.exists(save_abspath) is False:
+        return NumpyIndexer(index_filename="numpy-index.tgz", compress_level=1,
+                            metas={'workspace': WORKSPACE_DIR,
+                                   'warn_unnamed': False,
+                                   'separated_workspace': False,
+                                   'is_trained': False,
+                                   'max_snapshot': 0
+                                   })
+    else:
+        return BaseExecutor.load(save_abspath)
+
+
+def get_indexer(index_type: str = 'faiss'):
+    if index_type == 'faiss':
+        return get_faiss_indexer(FAISS_INDEXER_BIN_SAVE_PATH)
+    elif index_type == 'annoy':
+        return get_annoy_indexer(ANNOY_INDEXER_BIN_SAVE_PATH)
+    elif index_type == 'numpy':
+        return get_numpy_indexer(NUMPY_INDEXER_BIN_SAVE_PATH)
+
+
+def save_indexer(indexer: 'BaseNumpyIndexer', index_type: str = 'faiss'):
+    if index_type == 'faiss':
+        indexer.save(FAISS_INDEXER_BIN_SAVE_PATH)
+    elif index_type == 'annoy':
+        indexer.save(ANNOY_INDEXER_BIN_SAVE_PATH)
+    elif index_type == 'numpy':
+        indexer.save(NUMPY_INDEXER_BIN_SAVE_PATH)
+
+
 @click.command()
 @click.option('--batch_size', '-n', default=50)
 @click.option('--top_k', '-k', default=100)
-@click.option('--i', '-i', default=False, type=bool)
-@click.option('--t', '-t', default=False, type=bool)
-@click.option('--q', '-q', default=False, type=bool)
-@click.option('--e', '-e', default=False, type=bool)
-def main(batch_size, top_k, i, t, q, e):
-    with get_indexer() as idx:
-        if i:
-            index(idx, batch_size)
-            idx.save(INDEXER_BIN_SAVE_PATH)
+@click.option('--index_type', '-t', default='faiss')
+@click.option('--index', '-i', default=False, type=bool)
+@click.option('--warmup', '-w', default=False, type=bool)
+@click.option('--query', '-q', default=False, type=bool)
+@click.option('--evaluate', '-e', default=False, type=bool)
+def main(batch_size, top_k, index_type, index, warmup, query, evaluate):
+    print(f'Testing for index {index_type}')
+    with get_indexer(index_type) as idx:
+        if index:
+            do_index(idx, batch_size)
+            save_indexer(idx, index_type)
 
-    with get_indexer(save_abspath=INDEXER_BIN_SAVE_PATH) as idx:
-        if t:
-            train(idx)
-        if q:
-            results = query(idx, batch_size, top_k)
-            if e:
-                evaluate(results)
+    with get_indexer(index_type) as idx:
+        if warmup:
+            do_warmup(idx)
+        if query:
+            results = do_query(idx, batch_size, top_k)
+            if evaluate:
+                do_evaluate(results)
 
 
 if __name__ == '__main__':

--- a/vector_index/app.py
+++ b/vector_index/app.py
@@ -1,0 +1,119 @@
+import click
+import os
+import numpy as np
+from jina.executors import BaseExecutor
+from jina.executors.indexers.vector.faiss import FaissIndexer
+from jina.executors.indexers.vector import BaseNumpyIndexer
+from read_vectors_files import fvecs_read, ivecs_read
+from perf_timer import PerfTimer
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+WORKSPACE_DIR = os.path.join(os.path.dirname(__file__), "workspace")
+FAISS_DATA_DIR = os.path.join(os.path.join(os.path.dirname(__file__), "faiss_data"), "sift")
+INDEX_FEED_PATH = os.path.join(FAISS_DATA_DIR, "sift_base.fvecs")
+QUERY_FEED_PATH = os.path.join(FAISS_DATA_DIR, "sift_query.fvecs")
+GROUNDTRUTH_PATH = os.path.join(FAISS_DATA_DIR, 'sift_groundtruth.ivecs')
+INDEXER_BIN_SAVE_PATH = os.path.join(WORKSPACE_DIR, "indexer.bin")
+
+
+def read_data(db_file_path: str, batch_size: int, max_docs: int = None):
+    vectors = fvecs_read(db_file_path)
+    num_vectors = vectors.shape[0]
+    batch_size = 1 if batch_size == -1 else batch_size
+    num_batches = int(num_vectors / batch_size)
+
+    if max_docs is not None:
+        batch_size = max_docs
+        num_batches = 1
+
+    for i in range(1, num_batches + 1):
+        start_batch = (i - 1) * batch_size
+        end_batch = i * batch_size if i * batch_size < num_vectors else num_vectors
+        keys = np.arange(start_batch, end_batch).reshape(end_batch - start_batch, 1)
+        yield keys, vectors[start_batch: end_batch]
+
+
+def index(indexer: 'BaseNumpyIndexer', batch_size: int):
+    t = PerfTimer()
+    with t:
+        n = 0
+        for keys, vecs in read_data(INDEX_FEED_PATH, batch_size):
+            indexer.add(keys, vecs)
+            n += batch_size
+    print(f'Took {t.interval} m to index {n} documents: {n/t.interval}doc/s')
+
+
+def train(indexer: 'BaseNumpyIndexer'):
+    t = PerfTimer()
+    with t:
+        for keys, vecs in read_data(QUERY_FEED_PATH, batch_size=1, max_docs=100):
+            indexer.query(vecs, 1)
+    print(f'Took {t.interval} m to train and warmup the index')
+
+
+def query(indexer: 'BaseNumpyIndexer', batch_size: int, top_k: int):
+    results = np.empty((0, top_k), 'float32')
+    t = PerfTimer()
+    with t:
+        n = 0
+        for keys, vecs in read_data(QUERY_FEED_PATH, batch_size):
+            doc_ids, dists = indexer.query(vecs, top_k)
+            results = np.vstack((results, doc_ids))
+            n += batch_size
+    print(f'Took {t.interval} m to query {n} documents: {n/t.interval}doc/s')
+    return results
+
+
+def evaluate(results: np.array):
+    groundtruth = ivecs_read(GROUNDTRUTH_PATH)
+
+    def recall_at_k(k):
+        """
+        Computes how many times the true nearest neighbour is returned as one of the k closest vectors from a query.
+        Taken from https://gist.github.com/mdouze/046c1960bc82801e6b40ed8ee677d33e
+        """
+        eval = (results[:, :k] == groundtruth[:, :1]).sum() / float(results.shape[0])
+        return eval
+
+    for eval_point in [1, 10, 20, 50, 100]:
+        print(f'recall@{eval_point} = {recall_at_k(eval_point)}')
+
+
+def get_indexer(save_abspath: str = None):
+    if save_abspath is None:
+        return FaissIndexer(index_key='IVF10,PQ4', train_filepath=os.path.join(WORKSPACE_DIR, "train.tgz"),
+                            index_filename="index.tgz", compress_level=1,
+                            metas={'workspace': WORKSPACE_DIR,
+                                   'warn_unnamed': False,
+                                   'separated_workspace': False,
+                                   'is_trained': False,
+                                   'max_snapshot': 0
+                                   })
+    else:
+        return BaseExecutor.load(save_abspath)
+
+
+@click.command()
+@click.option('--batch_size', '-n', default=50)
+@click.option('--top_k', '-k', default=100)
+@click.option('--i', '-i', default=False, type=bool)
+@click.option('--t', '-t', default=False, type=bool)
+@click.option('--q', '-q', default=False, type=bool)
+@click.option('--e', '-e', default=False, type=bool)
+def main(batch_size, top_k, i, t, q, e):
+    with get_indexer() as idx:
+        if i:
+            index(idx, batch_size)
+            idx.save(INDEXER_BIN_SAVE_PATH)
+
+    with get_indexer(save_abspath=INDEXER_BIN_SAVE_PATH) as idx:
+        if t:
+            train(idx)
+        if q:
+            results = query(idx, batch_size, top_k)
+            if e:
+                evaluate(results)
+
+
+if __name__ == '__main__':
+    main()

--- a/vector_index/generate_training_data.py
+++ b/vector_index/generate_training_data.py
@@ -1,0 +1,14 @@
+import gzip
+import os
+from read_vectors_files import fvecs_read
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+WORKSPACE_DIR = os.path.join(os.path.dirname(__file__), "workspace")
+FAISS_DATA_DIR = os.path.join(os.path.join(os.path.dirname(__file__), "faiss_data"), "sift")
+TRAINING_FILE_PATH = os.path.join(DATA_DIR, "sift_learn.fvecs")
+
+train_filepath = os.path.join(WORKSPACE_DIR, "train.tgz")
+train_fvecs_path = os.path.join(FAISS_DATA_DIR, 'sift_learn.fvecs')
+train_data = fvecs_read(train_fvecs_path)
+with gzip.open(train_filepath, 'wb', compresslevel=1) as f:
+    f.write(train_data.tobytes())

--- a/vector_index/generate_training_data.sh
+++ b/vector_index/generate_training_data.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+mkdir workspace || true
+python3.7 generate_training_data.py

--- a/vector_index/get_sift.sh
+++ b/vector_index/get_sift.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+TEST_WORKDIR=./faiss_data/
+mkdir -p ${TEST_WORKDIR}
+cd ${TEST_WORKDIR}
+curl ftp://ftp.irisa.fr/local/texmex/corpus/sift.tar.gz --output sift.tar.gz
+tar zxf sift.tar.gz

--- a/vector_index/perf_timer.py
+++ b/vector_index/perf_timer.py
@@ -1,0 +1,11 @@
+import time
+
+
+class PerfTimer:
+    def __enter__(self):
+        self.start = time.clock()
+        return self
+
+    def __exit__(self, *args):
+        self.end = time.clock()
+        self.interval = self.end - self.start

--- a/vector_index/read_vectors_files.py
+++ b/vector_index/read_vectors_files.py
@@ -1,0 +1,11 @@
+import numpy as np
+
+
+def ivecs_read(fname):
+    a = np.fromfile(fname, dtype='int32')
+    d = a[0]
+    return a.reshape(-1, d + 1)[:, 1:].copy()
+
+
+def fvecs_read(fname):
+    return ivecs_read(fname).view('float32')


### PR DESCRIPTION
**Changes introduced**

Added a perf test that uses **SIFT1M** dataset from _http://corpus-texmex.irisa.fr/._ 

The dataset contains SIFT descriptors vectors of 128 dimensions: 
          **1,000,000** vectors to index
          **10,000** vectors to query
          **100,000** vectors to train the index.

In this test, FAISS, ANNOY and NUMPY Indexers are considered, althought NUMPY can't handle such a dataset.

The results obtained with the configuration in this test are (BATCHES OF 1000 docs):

FAISS
```
Indexing: 17.5 s (57129 doc/s)
Warm-up (training + loading index): 3245.750974 s
Querying: 9.73 s (1028 doc/s)
The evaluation with recall@K (considering only the nearest neighbor)
recall@1 = 0.3818
recall@10 = 0.417
recall@20 = 0.417
recall@50 = 0.417
recall@100 = 0.417
```
ANNOY
```
Indexing: 15.3 s ( 65462 doc/s)
Warm-up (training + loading index): 40.35s
Querying: 3.336 s (2997 doc/s)
The evaluation with recall@K (considering only the nearest neighbor)
recall@1 = 0.7009
recall@10 = 0.7062
recall@20 = 0.7062
recall@50 = 0.7062
recall@100 = 0.7062
```

Usage example:
`python app.py -n 1000 -t annoy -i True -w True -q True -e True`

Hardware details:

- **Processor**: 12 cores Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
- **Memory**: 16GB Ram
- **OS**: Ubuntu 18.04

**TODO**
Understand better the results. Did not expect such difference in performance ven with worse quality results for FAISS.
